### PR TITLE
Test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Currently only the Ionic mobile part is setup and can be used for development.
 - `npm run install-globals` 
 - `ionic serve`
 
+With the command `npm run install-clean` it's possible to install a fresh npm installation. This is handy when switching between branches with different node_modules and configurations or when new node_modules are introduced.
+
 **Note**: Only verified on webkit based browsers.
 
 ### Visual Studio Setup

--- a/config/helpers.js
+++ b/config/helpers.js
@@ -1,0 +1,7 @@
+var path = require('path');
+var _root = path.resolve(__dirname, '..');
+function root(args) {
+  args = Array.prototype.slice.call(arguments, 0);
+  return path.join.apply(path, [_root].concat(args));
+}
+exports.root = root;

--- a/config/karma-test-shim.js
+++ b/config/karma-test-shim.js
@@ -1,0 +1,21 @@
+Error.stackTraceLimit = Infinity;
+
+require('core-js/es6');
+require('core-js/es7/reflect');
+
+require('zone.js/dist/zone');
+require('zone.js/dist/long-stack-trace-zone');
+require('zone.js/dist/proxy');
+require('zone.js/dist/sync-test');
+require('zone.js/dist/jasmine-patch');
+require('zone.js/dist/async-test');
+require('zone.js/dist/fake-async-test');
+
+var appContext = require.context('../src', true, /\.spec\.ts/);
+
+appContext.keys().forEach(appContext);
+
+var testing = require('@angular/core/testing');
+var browser = require('@angular/platform-browser-dynamic/testing');
+
+testing.TestBed.initTestEnvironment(browser.BrowserDynamicTestingModule, browser.platformBrowserDynamicTesting());

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -1,0 +1,48 @@
+var webpackConfig = require('./webpack.test');
+
+module.exports = function (config) {
+  var _config = {
+    basePath: '',
+
+    frameworks: ['jasmine'],
+
+    files: [
+      {pattern: './karma-test-shim.js', watched: false}
+    ],
+
+    preprocessors: {
+      './karma-test-shim.js': ['webpack', 'sourcemap']
+    },
+
+    webpack: webpackConfig,
+
+    webpackMiddleware: {
+      stats: 'errors-only'
+    },
+
+    webpackServer: {
+      noInfo: false
+    },
+
+    htmlReporter: {
+      outputFile: '../.tmp/test-results.html',
+            
+      // Optional 
+      pageTitle: 'Unit Tests',
+      subPageTitle: 'megaTests',
+      groupSuites: true,
+      useCompactStyle: true,
+      useLegacyStyle: true
+    },
+
+    reporters: ['progress', 'html'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: false,
+    browsers: ['PhantomJS'],
+    singleRun: true
+  };
+
+  config.set(_config);
+};

--- a/config/tests/units.html
+++ b/config/tests/units.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Unit Tests - megaTests</title>
+    <style type="text/css">html,body{font-family:Arial,sans-serif;font-size:1rem;margin:0;padding:0;}body{padding:10px 40px;}h1{margin-bottom:0;}h2{margin-top:0;margin-bottom:0;color:#999;}table{width:100%;margin-top:20px;margin-bottom:20px;table-layout:fixed;}tr.header{background:#ddd;font-weight:bold;border-bottom:none;}td{padding:7px;border-top:none;border-left:1px black solid;border-bottom:1px black solid;border-right:none;word-break:break-all;word-wrap:break-word;}tr.pass td{color:#003b07;background:#86e191;}tr.skip td{color:#7d3a00;background:#ffd24a;}tr.fail td{color:#5e0e00;background:#ff9c8a;}tr:first-child td{border-top:1px black solid;}td:last-child{border-right:1px black solid;}tr.overview{font-weight:bold;color:#777;}tr.overview td{padding-bottom:0px;border-bottom:none;}tr.system-out td{color:#777;}tr.system-errors td{color:#f00;}hr{height:2px;margin:30px 0;background:#000;border:none;}section{margin-top:40px;}h3{margin:6px 0;}.overview{color:#333;font-weight:bold;}.system-out{margin:0.4rem 0;}.system-errors{color:#a94442}.spec{padding:0.8rem;margin:0.3rem 0;}.spec--pass{color:#3c763d;background-color:#dff0d8;border:1px solid #d6e9c6;}.spec--skip{color:#8a6d3b;background-color:#fcf8e3;border:1px solid #faebcc;}.spec--fail{color:#a94442;background-color:#f2dede;border:1px solid #ebccd1;}.spec--group{color:#636363;background-color:#f0f0f0;border:1px solid #e6e6e6;margin:0;}.spec--group:not(:first-of-type){margin:20px 0 0 0;}.spec__title{display:inline;}.spec__suite{display:inline;}.spec__descrip{font-weight:normal;}.spec__status{float:right;}.spec__log{padding-left: 2.3rem;}.hidden{display:none;}body.compact .spec p{margin-top:0;margin-bottom:0.5rem;}body.compact .spec,body.compact tr,body.compact .overview,body.compact .system-out,body.compact .system-errors{font-size:0.85rem;}body.compact .spec{padding:0.3rem 0.5rem;}body.compact section{margin-top:30px;}</style>
+  </head>
+  <body class="compact">
+    <h1>Unit Tests</h1>
+    <h2>megaTests</h2>
+    <table cellspacing="0" cellpadding="0" border="0">
+      <tr class="overview">
+        <td colspan="3" title="Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1">Browser: PhantomJS 2.1.1 (Windows 8 0.0.0)</td>
+      </tr>
+      <tr class="overview">
+        <td colspan="3">Timestamp: 12/14/2016, 10:16:38 PM</td>
+      </tr>
+      <tr>
+        <td colspan="3">
+          4 tests / 
+          0 errors / 
+          0 failures / 
+          0 skipped / 
+          runtime: 2.143s
+        </td>
+      </tr>
+      <tr class="header">
+        <td>Status</td>
+        <td>Spec</td>
+        <td>Suite / Results</td>
+      </tr>
+      <tr class="pass">
+        <td>Passed in 0.33s</td>
+        <td>getRoot(): receives an Observable&lt;Container&gt; async object</td>
+        <td>Synacta api conversion</td>
+      </tr>
+      <tr class="pass">
+        <td>Passed in 1.099s</td>
+        <td>getRoot(): subscribing returns a Container object</td>
+        <td>Synacta api conversion</td>
+      </tr>
+      <tr class="pass">
+        <td>Passed in 0.363s</td>
+        <td>getRoot(): the returned object contains correct data in base fields</td>
+        <td>Synacta api conversion</td>
+      </tr>
+      <tr class="pass">
+        <td>Passed in 0.351s</td>
+        <td>getRoot(): the returned object contains correct data in api fields</td>
+        <td>Synacta api conversion</td>
+      </tr>
+    </table>
+    <hr/>
+  </body>
+</html>

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -1,0 +1,37 @@
+var helpers = require('./helpers');
+
+module.exports = {
+  devtool: 'inline-source-map',
+
+  resolve: {
+    extensions: ['', '.ts', '.js']
+  },
+
+  module: {
+    loaders: [
+      {
+        test: /\.ts$/,
+        loaders: ['awesome-typescript-loader', 'angular2-template-loader']
+      },
+      {
+        test: /\.html$/,
+        loader: 'html'
+
+      },
+      {
+        test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/,
+        loader: 'null'
+      },
+      {
+        test: /\.css$/,
+        exclude: helpers.root('src', 'app'),
+        loader: 'null'
+      },
+      {
+        test: /\.css$/,
+        include: helpers.root('src', 'app'),
+        loader: 'raw'
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "@types/node": "^6.0.45",
     "concurrently": "^3.1.0",
     "electron-prebuilt": "^1.4.5",
-    "typescript": "~2.0.10",
+    "typescript": "~2.0.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "homepage": "",
   "private": true,
   "scripts": {
-    "postinstall": "typings install",
     "install-globals": "npm install ionic cordova -g",
+    "install-clean": "rm -R node_modules/ && npm install",
     "build": "ionic-app-scripts build",
     "watch": "ionic-app-scripts watch",
     "serve:before": "watch",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:before": "build",
     "run:before": "build",
     "typings": "typings",
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "test": "karma start config/karma.conf.js"
   },
   "dependencies": {
     "@angular/common": "2.1.1",
@@ -41,8 +42,31 @@
     "@ionic/app-scripts": "0.0.39",
     "@types/jasmine": "^2.5.35",
     "@types/node": "^6.0.45",
+    "angular2-template-loader": "^0.4.0",
+    "awesome-typescript-loader": "^2.2.4",
     "concurrently": "^3.1.0",
+    "css-loader": "^0.23.1",
     "electron-prebuilt": "^1.4.5",
-    "typescript": "~2.0.10"
+    "extract-text-webpack-plugin": "^1.0.1",
+    "file-loader": "^0.8.5",
+    "html-loader": "^0.4.3",
+    "html-webpack-plugin": "^2.15.0",
+    "jasmine-core": "^2.4.1",
+    "karma": "^1.2.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-htmlfile-reporter": "^0.3.4",
+    "karma-jasmine": "^1.0.2",
+    "karma-phantomjs-launcher": "^1.0.2",
+    "karma-sourcemap-loader": "^0.3.7",
+    "karma-webpack": "^1.8.0",
+    "null-loader": "^0.1.1",
+    "phantomjs-prebuilt": "^2.1.7",
+    "raw-loader": "^0.5.1",
+    "rimraf": "^2.5.2",
+    "style-loader": "^0.13.1",
+    "typescript": "~2.0.10",
+    "webpack": "^1.13.0",
+    "webpack-dev-server": "^1.14.1",
+    "webpack-merge": "^0.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
   },
   "devDependencies": {
     "@ionic/app-scripts": "0.0.39",
+    "@types/jasmine": "^2.5.35",
+    "@types/node": "^6.0.45",
     "concurrently": "^3.1.0",
     "electron-prebuilt": "^1.4.5",
-    "typescript": "2.0.6",
-    "typings": "^1.5.0"
+    "typescript": "~2.0.10",
   }
 }

--- a/src/core/synacta/api.service.spec.ts
+++ b/src/core/synacta/api.service.spec.ts
@@ -1,0 +1,154 @@
+import { TestBed, inject, async } from '@angular/core/testing';
+import { HttpModule } from '@angular/http';
+
+import { Observable } from 'rxjs/Observable';
+import { deserialize } from 'json-typescript-mapper';
+import { SynactaAPIService } from './api.service';
+import { IFrame, Frame, Entity, Container, Document } from './api.objects';
+
+describe("Synacta api conversion", () => {
+
+    let service: SynactaAPIService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ HttpModule ],
+            providers: [ SynactaAPIService ]
+        });
+    });
+
+    beforeEach(inject([SynactaAPIService], s => {
+        service = s;
+    }));
+
+    it("getRoot(): receives an Observable<Container> async object", () => {
+        let request;
+        request = service.getRoot();
+        expect(request instanceof Observable).toEqual(true);
+    });
+    
+    it("getRoot(): subscribing returns a Container object", async(() => {
+        service.getRoot().subscribe(response => { 
+            expect(response instanceof Container).toEqual(true);
+            expect(response.HasChild).toEqual(true);
+        });
+    }));
+
+    it("getRoot(): the returned object contains correct data in base fields", async(() => {
+        service.getRoot().subscribe(response => { 
+            expect(response.HasChild).toEqual(true);
+            expect(response.ParentID).toEqual("1");
+            expect(response.ObjectType).toEqual("Plan");
+        });
+    }));
+
+    it("getRoot(): the returned object contains correct data in api fields", async(() => {
+        service.getRoot().subscribe(response => { 
+            expect(response.ReadLink).toEqual(RootJson["@odata.readLink"]);
+        });
+    }));
+    
+});
+
+// JSON Mocks
+let RootFrameJson = {
+    "@odata.context": "http://synacta.agile-is.de/_api/base/Root",
+    "@odata.count": 1,
+    "FullODataLink@odata.navigationLink": "http://synacta.agile-is.de/_api/base/Root?$level=Full",
+    "value": [ 'test' ]
+}
+
+let RootJson = {
+    "Properties": {
+        "Organisation": " ",
+        "Stufe": "Plan",
+        "Zeichen": "NI.DMS",
+        "Bezeichnung": "NI.DMS"
+    },
+    "PropertyInfos": null,
+    "ID": "3df202ad-91b2-413a-9847-d12d536ed813",
+    "ObjectType": "Plan",
+    "ParentID": "1",
+    "ParentType": "Wurzel",
+    "IsVirtual": true,
+    "Frozen": false,
+    "HasChild": true,
+    "Hash": "822235546",
+    "@odata.readLink": "http://synacta.agile-is.de/_api/base/Plan/3df202ad-91b2-413a-9847-d12d536ed813",
+    "Child@odata.navigationLink": "http://synacta.agile-is.de/_api/base/Plan/3df202ad-91b2-413a-9847-d12d536ed813/Children",
+    "FullODataLink@odata.navigationLink": "http://synacta.agile-is.de/_api/base/Plan/3df202ad-91b2-413a-9847-d12d536ed813?$level=Full"
+}
+
+let ContainerJson = {
+        "Properties": {
+        "Typ": "Akte",
+        "Aktenplankennzeichen": "010",
+        "Ableitung": "23434",
+        "Aktenzeichen": "010/23434",
+        "Aktenbetreff": "342424",
+        "Schlagwörter": "",
+        "Themenverweis": "",
+        "Hinweise": "",
+        "Weiserzeichen": "",
+        "Medium": "Elektronisch",
+        "Geheimschutzstufe": "keine",
+        "Organisation": "DemoSite",
+        "Geschlossen": "",
+        "Aussonderung vorgesehen": "",
+        "Aussonderungsart": "B - Bewerten",
+        "Bewertungsvorschlag": "B - Bewerten",
+        "Altsystem Daten": "",
+        "Erstellt am": "2016-09-21T16:37:39",
+        "Erstellt von": "agile\\bhofmann",
+        "Geändert am": "2016-09-21T16:37:39",
+        "Geändert von": "agile\\bhofmann"
+    },
+    "PropertyInfos": null,
+    "ID": "68be47b7-0132-4751-b396-46a6d8e441d7",
+    "ObjectType": "Akte",
+    "ParentID": "4a9c23b4-c89b-4322-8421-adddab50dc8d",
+    "ParentType": "Obergruppe",
+    "IsVirtual": false,
+    "Frozen": false,
+    "HasChild": true,
+    "Hash": "1521639938",
+    "@odata.readLink": "http://synacta.agile-is.de/_api/base/Akte/68be47b7-0132-4751-b396-46a6d8e441d7",
+    "Child@odata.navigationLink": "http://synacta.agile-is.de/_api/base/Akte/68be47b7-0132-4751-b396-46a6d8e441d7/Children",
+    "Document@odata.navigationLink": "http://synacta.agile-is.de/_api/base/Akte/68be47b7-0132-4751-b396-46a6d8e441d7/Documents",
+    "FullODataLink@odata.navigationLink": "http://synacta.agile-is.de/_api/base/Akte/68be47b7-0132-4751-b396-46a6d8e441d7?$level=Full"
+}
+
+let DocumentJson = {
+    "Properties": {
+        "Name": "demofile1",
+        "Dokumentdatum": "2016-09-27T00:00:00",
+        "Schlagwörter": "",
+        "Hinweise": "",
+        "Mappe": "",
+        "Ausgechecked von": "",
+        "Weiserzeichen": "",
+        "Ausgechecked am": "",
+        "Geheimschutzstufe": "",
+        "Organisation": "DemoSite",
+        "Akte/Vorgang": "010/23434",
+        "Dokumentnr.": "2016/00001",
+        "Altsystem Daten": "",
+        "Erstellt am": "2016-09-27T14:28:40",
+        "Erstellt von": "agile\\bhofmann",
+        "Geändert am": "2016-09-27T14:28:40",
+        "Geändert von": "agile\\bhofmann",
+        "Titel": "",
+        "Erweiterung": "docx"
+    },
+    "PropertyInfos": null,
+    "ID": "15f02799-10db-4dc0-91e0-576c06ebd35f",
+    "ObjectType": "Dokument",
+    "ParentID": "68be47b7-0132-4751-b396-46a6d8e441d7",
+    "ParentType": "Akte",
+    "Frozen": false,
+    "CheckedOutBy": "",
+    "Version": "1",
+    "Hash": "-1909780614",
+    "@odata.readLink": "http://synacta.agile-is.de/_api/base/Dokument/15f02799-10db-4dc0-91e0-576c06ebd35f",
+    "FullODataLink@odata.navigationLink": "http://synacta.agile-is.de/_api/base/Dokument/15f02799-10db-4dc0-91e0-576c06ebd35f?$level=Full"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,16 +8,22 @@
       "dom",
       "es2015"
     ],
-    "module": "es2015",
+    "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
-    "target": "es5"
+    "target": "es5",
+    "suppressImplicitAnyIndexErrors": true,
+    "typeRoots": [
+      "../../node_modules/@types/" 
+    ],
+    "types": [
+      "jasmine",
+      "node"
+    ]
   },
-  "include": [
-    "src/**/*.ts"
-  ],
   "exclude": [
-    "node_modules"
+    "node_modules/*",
+    "**/*-aot.ts"
   ],
   "compileOnSave": false,
   "atom": {

--- a/typings.json
+++ b/typings.json
@@ -1,9 +1,0 @@
-{
-  "name": "ionic-app-base",
-  "dependencies": {},
-  "globalDependencies": {
-    "core-js": "registry:dt/core-js#0.0.0+20160914114559",
-    "github-electron": "registry:dt/github-electron#1.4.2+20161012142539",
-    "node": "registry:dt/node#6.0.0+20161019125345"
-  }
-}


### PR DESCRIPTION
Adding the Testframework.

Tests can be run with the `npm test` command. Test results will output on the console and will be run in a browser. A summery can be found in the file `.tmp/test-results.html`.

Console output will print a stack-trace when errors occur.

**It's necessary to run the command `npm run install-clean` after the pull to prevent version problems in your node_modules. This command is newly introduced to prevent node_module version errors when switching between branches or when new features are introduced like this one.** 

**Todo**: Add Chrome-Test-Runner so the Tests can be debugged in a separate chrome instance.