### PR TITLE
Erste Settings Service implementierung

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { SynactaAPIService } from '../core/synacta/api.service';
 import { Favorits } from '../core/storage/favorits';
 import { Storage } from '../core/storage/storage';
 import { RecentList } from '../core/storage/recentList'
+import { SettingsService } from '../core/settings/settings.service';
 
 @NgModule({
   declarations: [
@@ -18,7 +19,7 @@ import { RecentList } from '../core/storage/recentList'
     FavoritePage,
     BrowserPage,
     RecentPage,
-	OptionsPage,
+	  OptionsPage,
     TabsPage
   ],
   imports: [
@@ -31,14 +32,15 @@ import { RecentList } from '../core/storage/recentList'
     FavoritePage,
     BrowserPage,
     RecentPage,
-	OptionsPage,
+	  OptionsPage,
     TabsPage
   ],
   providers: [
     SynactaAPIService,
     Favorits,
     Storage,
-    RecentList
+    RecentList,
+    SettingsService
   ]
 })
 export class AppModule {}

--- a/src/core/settings/settings.service.spec.ts
+++ b/src/core/settings/settings.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { SettingsService } from './settings.service';
+
+describe("Settings Service", () => {
+
+    let settings: SettingsService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [ SettingsService ]
+        });
+    });
+
+    beforeEach(inject([SettingsService], s => {
+        settings = s;
+    }));
+
+    it("Constructs correctly.", () => {
+        expect(settings.vault).toBeDefined();
+    });
+
+    it("Can save and load values to and from local storage.", () => {
+        settings.vault.startPage = 'newTestValue';
+        settings.save();
+        settings.vault.startPage = 'otherValue';
+        expect(settings.vault.startPage).toEqual('otherValue');
+        settings.load();
+        expect(settings.vault.startPage).toEqual('newTestValue');
+    });
+});

--- a/src/core/settings/settings.service.ts
+++ b/src/core/settings/settings.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+
+export interface Settings {
+    startPage: string;
+    background: Color;
+    accent: Color;
+}
+
+@Injectable()
+export class SettingsService {
+
+    vault: Settings;
+
+    constructor() {
+        this.vault = { 
+            startPage: 'RecentPage',
+            background: Color.Blue,
+            accent: Color.Black
+        };
+    }
+
+    save() {
+        window.localStorage.setItem('settings', JSON.stringify(this.vault));
+    }
+
+    load() {
+        this.vault = JSON.parse(window.localStorage.getItem('settings'));
+    }
+
+}
+
+export enum Color {
+    Blue, Black, White
+}


### PR DESCRIPTION
Diese Implementierung ist recht einfach gehalten und erlaubt das Anwendungsübergreifende speichern und laden von Optionen.

Um Optionen hinzuzufügen muss dem Interface in ```settings.service.ts``` weitere Felder zugefügt werden.

Zum Laden/Speichern settings.save() oder settings.load()

```
constructor(private settings: SettingsService) {
  // SettingsService ist jetzt member von dieser Klasse
}
// start page option lesen
let startPage = settings.vault.startPage;
```